### PR TITLE
correctly align v-container with fill-height

### DIFF
--- a/packages/vuetify/src/components/VGrid/VGrid.sass
+++ b/packages/vuetify/src/components/VGrid/VGrid.sass
@@ -7,6 +7,11 @@
 
   &--fluid
     max-width: 100%
+    
+  &.fill-height
+    align-items: center
+    display: flex
+    flex-wrap: wrap
 
 // Row
 //


### PR DESCRIPTION
apply to a v-container, fill-height property have to set display flex and default align-items center to vertical align container (backport from v2.x)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

